### PR TITLE
Fix global variables leakage

### DIFF
--- a/23062902_Tezos/functions.js
+++ b/23062902_Tezos/functions.js
@@ -69,8 +69,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -80,8 +80,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), strokeWeight(FRAME_WIDTH / 10), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     beginShape()
     for (let x = -vertexX; x <= vertexX; x++) {

--- a/23070101_Digits/functions.js
+++ b/23070101_Digits/functions.js
@@ -73,8 +73,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -84,8 +84,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), strokeWeight(FRAME_WIDTH / 10), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     beginShape()
     for (let x = -vertexX; x <= vertexX; x++) {

--- a/23070201_Video2/functions.js
+++ b/23070201_Video2/functions.js
@@ -73,8 +73,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -84,8 +84,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), strokeWeight(FRAME_WIDTH / 10), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     beginShape()
     for (let x = -vertexX; x <= vertexX; x++) {

--- a/23070202_Error/functions.js
+++ b/23070202_Error/functions.js
@@ -73,8 +73,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -84,8 +84,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), strokeWeight(FRAME_WIDTH / 10), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     beginShape()
     for (let x = -vertexX; x <= vertexX; x++) {

--- a/23072601_SmileyFace/functions.js
+++ b/23072601_SmileyFace/functions.js
@@ -73,8 +73,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -84,8 +84,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), strokeWeight(FRAME_WIDTH / 10), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     beginShape()
     for (let x = -vertexX; x <= vertexX; x++) {

--- a/23072602_Invaders/functions.js
+++ b/23072602_Invaders/functions.js
@@ -73,8 +73,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -84,8 +84,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), strokeWeight(FRAME_WIDTH / 10), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     beginShape()
     for (let x = -vertexX; x <= vertexX; x++) {

--- a/23072701_Hourglass/functions.js
+++ b/23072701_Hourglass/functions.js
@@ -73,8 +73,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -84,8 +84,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), strokeWeight(FRAME_WIDTH / 10), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     beginShape()
     for (let x = -vertexX; x <= vertexX; x++) {

--- a/23072702_MentalImage/functions.js
+++ b/23072702_MentalImage/functions.js
@@ -73,8 +73,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -84,8 +84,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), strokeWeight(FRAME_WIDTH / 10), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/23072801_MentalImage/functions.js
+++ b/23072801_MentalImage/functions.js
@@ -98,8 +98,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -109,8 +109,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/23072802_MentalImage/functions.js
+++ b/23072802_MentalImage/functions.js
@@ -108,8 +108,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -119,8 +119,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/23072808_Spaceship/functions copy.js
+++ b/23072808_Spaceship/functions copy.js
@@ -108,8 +108,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -119,8 +119,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/23072808_Spaceship/functions.js
+++ b/23072808_Spaceship/functions.js
@@ -108,8 +108,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -119,8 +119,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/23081101_Blocks/functions.js
+++ b/23081101_Blocks/functions.js
@@ -123,8 +123,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -134,8 +134,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/23082502_AudioVisualizer/functions.js
+++ b/23082502_AudioVisualizer/functions.js
@@ -123,8 +123,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -134,8 +134,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/23082603_BlinkingBlocks/functions.js
+++ b/23082603_BlinkingBlocks/functions.js
@@ -164,8 +164,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -175,8 +175,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/23082603_MentalImage/functions.js
+++ b/23082603_MentalImage/functions.js
@@ -170,8 +170,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -181,8 +181,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/23083001_Birds/functions.js
+++ b/23083001_Birds/functions.js
@@ -163,8 +163,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -174,8 +174,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/23100301_Font/functions.js
+++ b/23100301_Font/functions.js
@@ -168,8 +168,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -179,8 +179,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/24032401_DominantColors/functions.js
+++ b/24032401_DominantColors/functions.js
@@ -189,8 +189,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -200,8 +200,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/24032801_PatreonCoverImg/functions.js
+++ b/24032801_PatreonCoverImg/functions.js
@@ -189,8 +189,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -200,8 +200,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/24032901_OmochiskyLogo/functions.js
+++ b/24032901_OmochiskyLogo/functions.js
@@ -185,8 +185,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -196,8 +196,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/24033101_RayrootLogoImg/functions.js
+++ b/24033101_RayrootLogoImg/functions.js
@@ -189,8 +189,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -200,8 +200,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/24040101_OmochiskyHeader/functions.js
+++ b/24040101_OmochiskyHeader/functions.js
@@ -185,8 +185,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -196,8 +196,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/24040102_MentalImage/functions.js
+++ b/24040102_MentalImage/functions.js
@@ -201,8 +201,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -212,8 +212,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/24040301_Busy/functions.js
+++ b/24040301_Busy/functions.js
@@ -163,8 +163,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -174,8 +174,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/24040801_FoldLine/functions.js
+++ b/24040801_FoldLine/functions.js
@@ -163,8 +163,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -174,8 +174,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/24040802_RisingSun/functions.js
+++ b/24040802_RisingSun/functions.js
@@ -191,8 +191,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -202,8 +202,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/24040803_Words/functions.js
+++ b/24040803_Words/functions.js
@@ -193,8 +193,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -204,8 +204,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/24042501_Start/functions.js
+++ b/24042501_Start/functions.js
@@ -193,8 +193,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -204,8 +204,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/24051301_Untitled/functions.js
+++ b/24051301_Untitled/functions.js
@@ -193,8 +193,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -204,8 +204,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)

--- a/24052101_MentalImage/functions.js
+++ b/24052101_MentalImage/functions.js
@@ -193,8 +193,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠
     noStroke(), fill(fillColor)
 
-    centerX = width / 2 - frameWidth / 2
-    centerY = height / 2 - frameWidth / 2
+    const centerX = width / 2 - frameWidth / 2
+    const centerY = height / 2 - frameWidth / 2
 
     rect(-centerX, 0, frameWidth, height)
     rect(centerX, 0, frameWidth, height)
@@ -204,8 +204,8 @@ function addFrame(fillColor, strokeColor, frameWidth) {
     // 枠線
     stroke(strokeColor), noFill()
 
-    vertexX = width / 2 - frameWidth
-    vertexY = height / 2 - frameWidth
+    const vertexX = width / 2 - frameWidth
+    const vertexY = height / 2 - frameWidth
 
     noiseLine(-vertexX, -vertexY, vertexX, -vertexY)
     noiseLine(-vertexX, vertexY, vertexX, vertexY)


### PR DESCRIPTION
## Summary
- ensure frame drawing helper uses local variables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cdefcfb60832d845c953dd651909c